### PR TITLE
Allowed_hosts updated in nrpe.cfg

### DIFF
--- a/templates/nrpe.cfg
+++ b/templates/nrpe.cfg
@@ -20,7 +20,7 @@ command_timeout={{ nrpe_command_timeout }}
 {% if nrpe_connection_timeout is defined %}
 connection_timeout={{nrpe_connection_timeout}} 
 {% endif %}
-allowed_hosts=::1,127.0.0.1,{% set comma = joiner(",") %}{% for host in groups['monitoring-servers'] %}{{ comma() }}{{ host }}{% endfor %}
+allowed_hosts={{ nagios_allowed_hosts | join(",") }}{% if nagios_allowed_hosts and groups['monitoring-servers'] %},{% endif %}{{ groups['monitoring-servers'] | join(",") }}
 
 include_dir={{ nrpe_conf_dir }}/nrpe.d/
 


### PR DESCRIPTION
This allows the variable nagios_allowed_hosts to be set in order to define the nrpe.cfg allowed_from value rather than only relying on monitoring-servers host group.  Should be backward-compatible