### PR TITLE
Minor update to fix ignores

### DIFF
--- a/templates/hostgroups.cfg
+++ b/templates/hostgroups.cfg
@@ -1,14 +1,18 @@
-{% set nagios_all_hosts_to_ignore=nagios_hosts_ignore %}
+{% set nagios_all_hosts_to_ignore = [] -%}
+
+{%- for host in nagios_hosts_ignore  %}
+{% if nagios_all_hosts_to_ignore.append(host) %}{% endif %}
+{% endfor -%}
+
 {% for host_group in groups %}
 {% if host_group in nagios_groups_ignore %}
 {% for host in groups[host_group] %}
-{% if nagios_all_hosts_to_ignore.append(host) %}
-{% endif %}
+{% if nagios_all_hosts_to_ignore.append(host) %}{% endif %}
 {% endfor %}
 {% endif %}
-{% endfor %}
+{% endfor -%}
 
-{% for host_group in groups if not host_group=="ungrouped" %}
+{%- for host_group in groups if not ( host_group=="ungrouped" or host_group=="all" ) %}
 {% if host_group not in nagios_groups_ignore %}
 define hostgroup {
   hostgroup_name  {{ host_group }}

--- a/templates/hosts.cfg
+++ b/templates/hosts.cfg
@@ -17,12 +17,16 @@ define host{
   notification_interval           120                    ; Resend notifications every 2 hours
 }
 
-{% set nagios_all_hosts_to_ignore=nagios_hosts_ignore %}
+{% set nagios_all_hosts_to_ignore = [] %}
+
+{% for host in nagios_hosts_ignore  %}
+{% if nagios_all_hosts_to_ignore.append(host) %}{% endif %}
+{% endfor %}
+
 {% for host_group in groups %}
 {% if host_group in nagios_groups_ignore %}
 {% for host in groups[host_group] %}
-{% if nagios_all_hosts_to_ignore.append(host) %}
-{% endif %}
+{% if nagios_all_hosts_to_ignore.append(host) %}{% endif %}
 {% endfor %}
 {% endif %}
 {% endfor %}


### PR DESCRIPTION
Thanks for implementing the Ignores changes, however this minor change was needed to allow the ignore to work for me correctly.  

Additionally, I believe the "all" group would be best left off from the hostgroups configuration (see https://github.com/sdarwin/ansible-nagios/compare/master...mm0:fix-host/group-ignore?expand=1#diff-29b66b4ea1a4fa454f0eb583e43248d1R15) since this would place hosts in a minimum of two nagios hostgroups(all + actual group).  Everything but this line should be backwards-compatible.  I will leave it up to you to decide whether to exclude the "all" group or not.