### PR TITLE
Adding variable for customizing ansible inventory group name

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ Email is a recommended prerequisite, with choices of Exim, Postfix, and others.
 
 ## Role Variables
 
-All the variables in the defaults/ directory may be overridden or changed. 
+All the variables in the defaults/ directory may be overridden or changed.
+
+The default ansible inventory group `monitoring-servers` can be customized with the `nagios_monitoring_servers_group_name` variable.
 
 ### Contacts/Users:
 
@@ -61,7 +63,7 @@ Ansible hosts in the 'all' group are converted to nagios monitored hosts. No con
 
 ### Nagios Hostgroups:
 
-Ansible groups are converted to nagios hostgroups. No configuration required. 
+Ansible groups are converted to nagios hostgroups. No configuration required.
 
 ## Skipping Hosts and Hostgroups
 
@@ -108,4 +110,3 @@ BSD
 
 By Sam Darwin, 2016. Based on pre-existing roles, see ACKNOWLEDGEMENTS.md file.
 Feedback and bug reports welcome.
-

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -135,6 +135,11 @@ nrpe_checks:
 nagios_hosts_ignore: ""
 nagios_groups_ignore: ""
 
+### If needed, you can completely disable web login authentication by setting this variable to false
+### Default: `nagios_login_auth: "true"`
+
+nagios_web_login_auth: "true"
+
 # nagios_allowed_hosts will automatically include the "monitoring-servers" as well
 nagios_allowed_hosts:
   - 127.0.0.1
@@ -145,4 +150,3 @@ nagios_monitoring_servers_group_name: "monitoring-servers"
 # Set this to remove the Ansible "all" group. In that case, be sure to add at least one new Ansible group, and one new service check in the nagios_host_groups variable
 #nagios_remove_all_group: "yes"
 nagios_remove_all_group: "no"
-

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -136,9 +136,9 @@ nagios_hosts_ignore: ""
 nagios_groups_ignore: ""
 
 ### If needed, you can completely disable web login authentication by setting this variable to false
-### Default: `nagios_web_login_auth: "true"`
+### Default: `nagios_web_login_auth: true`
 
-nagios_web_login_auth: "true"
+nagios_web_login_auth: true
 
 # nagios_allowed_hosts will automatically include the "monitoring-servers" as well
 nagios_allowed_hosts:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -140,6 +140,8 @@ nagios_allowed_hosts:
   - 127.0.0.1
   - ::1
 
+nagios_monitoring_servers_group_name: "monitoring-servers"
+
 # Set this to remove the Ansible "all" group. In that case, be sure to add at least one new Ansible group, and one new service check in the nagios_host_groups variable
 #nagios_remove_all_group: "yes"
 nagios_remove_all_group: "no"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -136,7 +136,7 @@ nagios_hosts_ignore: ""
 nagios_groups_ignore: ""
 
 ### If needed, you can completely disable web login authentication by setting this variable to false
-### Default: `nagios_login_auth: "true"`
+### Default: `nagios_web_login_auth: "true"`
 
 nagios_web_login_auth: "true"
 

--- a/tasks/configs.yml
+++ b/tasks/configs.yml
@@ -83,4 +83,6 @@
     owner: root
     group: root
     mode: 0644
+    backup: yes
+    force: yes
   when: nagios_web_login_auth == false

--- a/tasks/configs.yml
+++ b/tasks/configs.yml
@@ -73,4 +73,14 @@
   with_items:
     - localhost
   when: nagios_removelocalhost is defined or 'localhost' in groups['all']
- 
+
+- name: Disable web login authentication
+  become: true
+  notify: restart apache
+  template:
+    src: nagios.conf
+    dest: /etc/apache2/conf-available/nagios.conf
+    owner: root
+    group: root
+    mode: 0644
+  when: nagios_web_login_auth == false

--- a/templates/cgi.cfg
+++ b/templates/cgi.cfg
@@ -82,7 +82,11 @@ use_authentication=1
 # define this variable, anyone who has not authenticated to the web
 # server will inherit all rights you assign to this user!
 
+{% if nagios_web_login_auth == true %}
 #default_user_name=guest
+{% else %}
+default_user_name={{ nagios_monitoring_user }}
+{% endif %}
 
 # SYSTEM/PROCESS INFORMATION ACCESS
 # This option is a comma-delimited list of all usernames that

--- a/templates/nagios.conf
+++ b/templates/nagios.conf
@@ -1,0 +1,68 @@
+# SAMPLE CONFIG SNIPPETS FOR APACHE WEB SERVER
+#
+# This file contains examples of entries that need
+# to be incorporated into your Apache web server
+# configuration file.  Customize the paths, etc. as
+# needed to fit your system.
+
+ScriptAlias /nagios/cgi-bin "/usr/local/nagios/sbin"
+
+<Directory "/usr/local/nagios/sbin">
+#  SSLRequireSSL
+   Options ExecCGI
+   AllowOverride None
+   <IfVersion >= 2.3>
+      <RequireAll>
+         Require all granted
+#        Require host 127.0.0.1
+
+         AuthName "Nagios Access"
+         AuthType none
+#         AuthUserFile /usr/local/nagios/etc/htpasswd.users
+#         Require valid-user
+      </RequireAll>
+   </IfVersion>
+   <IfVersion < 2.3>
+      Order allow,deny
+      Allow from all
+#     Order deny,allow
+#     Deny from all
+#     Allow from 127.0.0.1
+
+      AuthName "Nagios Access"
+      AuthType none
+#      AuthUserFile /usr/local/nagios/etc/htpasswd.users
+#      Require valid-user
+   </IfVersion>
+</Directory>
+
+Alias /nagios "/usr/local/nagios/share"
+
+<Directory "/usr/local/nagios/share">
+#  SSLRequireSSL
+   Options None
+   AllowOverride None
+   <IfVersion >= 2.3>
+      <RequireAll>
+         Require all granted
+#        Require host 127.0.0.1
+
+         AuthName "Nagios Access"
+         AuthType none
+#         AuthUserFile /usr/local/nagios/etc/htpasswd.users
+#         Require valid-user
+      </RequireAll>
+   </IfVersion>
+   <IfVersion < 2.3>
+      Order allow,deny
+      Allow from all
+#     Order deny,allow
+#     Deny from all
+#     Allow from 127.0.0.1
+
+      AuthName "Nagios Access"
+      AuthType none
+#      AuthUserFile /usr/local/nagios/etc/htpasswd.users
+#      Require valid-user
+   </IfVersion>
+</Directory>

--- a/templates/nrpe.cfg
+++ b/templates/nrpe.cfg
@@ -2,10 +2,10 @@
 log_facility={{nrpe_log_facility}}
 {% endif %}
 {% if nrpe_allow_bash_command_substitution is defined %}
-allow_bash_command_substitution={{nrpe_allow_bash_command_substitution}} 
+allow_bash_command_substitution={{nrpe_allow_bash_command_substitution}}
 {% endif %}
 {% if nrpe_command_prefix is defined %}
-command_prefix={{nrpe_command_prefix}} 
+command_prefix={{nrpe_command_prefix}}
 {% endif %}
 pid_file={{ nrpe_pid_file }}
 server_port={{ nrpe_server_port }}
@@ -18,9 +18,8 @@ dont_blame_nrpe={{ nrpe_dont_blame_nrpe }}
 debug={{ nrpe_debug }}
 command_timeout={{ nrpe_command_timeout }}
 {% if nrpe_connection_timeout is defined %}
-connection_timeout={{nrpe_connection_timeout}} 
+connection_timeout={{nrpe_connection_timeout}}
 {% endif %}
-allowed_hosts={{ nagios_allowed_hosts | join(",") }}{% if nagios_allowed_hosts and groups['monitoring-servers'] %},{% endif %}{{ groups['monitoring-servers'] | join(",") }}
+allowed_hosts={{ nagios_allowed_hosts | join(",") }}{% if nagios_allowed_hosts and groups[nagios_monitoring_servers_group_name] %},{% endif %}{{ groups[nagios_monitoring_servers_group_name] | join(",") }}
 
 include_dir={{ nrpe_conf_dir }}/nrpe.d/
-


### PR DESCRIPTION
My organization has a substantial ansible inventory and the existing group name in this role (monitoring-servers) is already in use elsewhere and can not be changed. 

I needed to be able to customize this, and I am sure that others would like to customize it as well. 

I've added in the variable to defaults/main.yml and updated the README to reflect the change as well!