### PR TITLE
Change nagios_plugin_packages to match Debian-family.yml

### DIFF
--- a/tasks/setup-Debian-family-prerequisites.yml
+++ b/tasks/setup-Debian-family-prerequisites.yml
@@ -42,7 +42,7 @@
 
 - name: Install Plugin prerequisites for Debian family
   apt:
-    name: "{{ nagios_plugin_packages }}" 
+    name: "{{ default_nagios_plugin_packages }}" 
 
 #not supported on 16.04
 - name: Install Plugin prerequisites for Ubuntu


### PR DESCRIPTION
Change nagios_plugin_packages to default_nagios_plugin_packages which is the value in vars/Debian-family.yml

The value nagios_plugin_packages does not exist and will fail since the variable does not exist. 