### PR TITLE
Add nagios_{client,server}_enabled variables with backwards compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@
 .kitchen
 test.txt
 /.cache
-
+.venv/
+.ansible/

--- a/.yamllint
+++ b/.yamllint
@@ -13,3 +13,5 @@ rules:
   octal-values:
     forbid-implicit-octal: true
     forbid-explicit-octal: true
+ignore:
+  .venv/

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # defaults file for nagios
-nagios_client_enabled: false
-nagios_server_enabled: false
+run_nagios_client: false
+run_nagios_server: false
 
 nrpe_plugin_dir: /usr/lib/nagios/plugins
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,8 @@
 ---
 # defaults file for nagios
+nagios_client_enabled: false
+nagios_server_enabled: false
+
 nrpe_plugin_dir: /usr/lib/nagios/plugins
 
 # Directory that will be used as the location for the downloads§

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,8 +19,8 @@
 
 - name: Include client
   ansible.builtin.import_tasks: client.yml
-  when: run_nagios_client | default(false) | bool
+  when: nagios_client_enabled | default(run_nagios_client) | default(false) | bool
 
 - name: Include server
   ansible.builtin.import_tasks: server.yml
-  when: run_nagios_server | default(false) | bool
+  when: nagios_server_enabled | default(run_nagios_server) | default(false) | bool

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,12 +19,12 @@
 
 - name: Include client
   ansible.builtin.import_tasks: client.yml
-  when: >
-    (nagios_client_enabled is defined and nagios_client_enabled | bool) or
-    (nagios_client_enabled is not defined and run_nagios_client is defined)
+  when:
+    - run_nagios_client is defined
+    - run_nagios_client | bool
 
 - name: Include server
   ansible.builtin.import_tasks: server.yml
-  when: >
-    (nagios_server_enabled is defined and nagios_server_enabled | bool) or
-    (nagios_server_enabled is not defined and run_nagios_server is defined)
+  when:
+    - run_nagios_server is defined
+    - run_nagios_server | bool

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,8 +19,12 @@
 
 - name: Include client
   ansible.builtin.import_tasks: client.yml
-  when: nagios_client_enabled | default(run_nagios_client) | default(false) | bool
+  when: >
+    (nagios_client_enabled is defined and nagios_client_enabled | bool) or
+    (nagios_client_enabled is not defined and run_nagios_client is defined)
 
 - name: Include server
   ansible.builtin.import_tasks: server.yml
-  when: nagios_server_enabled | default(run_nagios_server) | default(false) | bool
+  when: >
+    (nagios_server_enabled is defined and nagios_server_enabled | bool) or
+    (nagios_server_enabled is not defined and run_nagios_server is defined)

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,8 +19,8 @@
 
 - name: Include client
   ansible.builtin.import_tasks: client.yml
-  when: run_nagios_client is defined
+  when: run_nagios_client | default(false) | bool
 
 - name: Include server
   ansible.builtin.import_tasks: server.yml
-  when: run_nagios_server is defined
+  when: run_nagios_server | default(false) | bool


### PR DESCRIPTION
## Summary

Add `nagios_{client,server}_enabled` variables with backwards compatibility and improve boolean validation

## Description

Introduces properly declared boolean variables (`nagios_client_enabled`, `nagios_server_enabled`) to improve integration with configuration management tools like Foreman, while maintaining backwards compatibility with existing `run_nagios_{client,server}` variables.

## Changes

- **feat**: Add `nagios_client_enabled` and `nagios_server_enabled` boolean variables in defaults/
- **feat**: Maintain backwards compatibility with existing `run_nagios_{client,server}` variables  
- **fix**: Improve boolean validation to properly handle truthy/falsy values (e.g., `'false'` and `'no'` strings now correctly evaluate as `false`)
- **chore**: Update .gitignore and .yamllint to ignore .venv/ and .ansible/ directories